### PR TITLE
Repo name updated in Docker files of  ros base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,6 @@ docker build -t ghcr.io/soham2560/humble-garden -f humble-garden/Dockerfile humb
 * `-t ghcr.io/soham2560/<image_name>`:  Tags the image with the specified name and registry path.
 * `-f <image_name>/Dockerfile`: Specifies the path to the Dockerfile to use for building the image.
 * `<image_name>`:  The build context, which is the directory containing the Dockerfile and any other files needed for the build.
-* 
-
-### **⚠️ Network Issue with ROS Docker Builds on IIIT Wi-Fi**
-
-If you try to build a Docker image using **any ROS base image** while connected to  **IIIT college Wi-Fi** , the build **will fail** with a network error:
-
-```
-gpg: keyserver receive failed: Network is unreachable
-```
-
-This happens because IIIT Wi-Fi **blocks connections** to external GPG keyservers needed for verification.
-
-**✅ Solution:**
-Use a **mobile hotspot or another unrestricted network** to successfully build your base ROS image.
 
 ### 3. Pushing an Image (For Contributors)
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This repository provides Docker images designed to simplify ROS 2 and ROS 1 deve
 
 The following Docker images are available:
 
-*   `humble`:  Based on `ubuntu:jammy`, this image includes ROS 2 Humble Hawksbill packages and a non-root user for enhanced security.
-*   `humble-garden`:  Extends the `humble` image and includes Gazebo Garden, a powerful 3D robotics simulator.
-*   `humble-fortress`:  Extends the `humble` image and includes Gazebo Fortress, which is the LTS and default sim for `humble`.
-*   `humble-harmonic`:  Extends the `humble` image and includes Gazebo Harmonic, which works better with `humble` related deps. Hence this is **Recommended**.
-*   `iron`: Based on `ubuntu:jammy`, this image includes ROS 2 Iron Irwini packages and a non-root user.
-*   `iron-garden`: Extends the `iron` image and includes Gazebo Garden.
-*   `noetic`: Based on `ubuntu:focal`, this image includes ROS Noetic Ninjemys packages and a non-root user.
+* `humble`:  Based on `ubuntu:jammy`, this image includes ROS 2 Humble Hawksbill packages and a non-root user for enhanced security.
+* `humble-garden`:  Extends the `humble` image and includes Gazebo Garden, a powerful 3D robotics simulator.
+* `humble-fortress`:  Extends the `humble` image and includes Gazebo Fortress, which is the LTS and default sim for `humble`.
+* `humble-harmonic`:  Extends the `humble` image and includes Gazebo Harmonic, which works better with `humble` related deps. Hence this is **Recommended**.
+* `iron`: Based on `ubuntu:jammy`, this image includes ROS 2 Iron Irwini packages and a non-root user.
+* `iron-garden`: Extends the `iron` image and includes Gazebo Garden.
+* `noetic`: Based on `ubuntu:focal`, this image includes ROS Noetic Ninjemys packages and a non-root user.
 
 **Important Note:** The `iron` and `iron-garden` images are currently **under development** and have not been heavily tested.  They may be unstable or contain significant bugs.
 
@@ -48,10 +48,24 @@ docker build -t ghcr.io/soham2560/humble-garden -f humble-garden/Dockerfile humb
 
 **Explanation of the `docker build` command:**
 
-*   `docker build`: The command to build a Docker image.
-*   `-t ghcr.io/soham2560/<image_name>`:  Tags the image with the specified name and registry path.
-*   `-f <image_name>/Dockerfile`: Specifies the path to the Dockerfile to use for building the image.
-*   `<image_name>`:  The build context, which is the directory containing the Dockerfile and any other files needed for the build.
+* `docker build`: The command to build a Docker image.
+* `-t ghcr.io/soham2560/<image_name>`:  Tags the image with the specified name and registry path.
+* `-f <image_name>/Dockerfile`: Specifies the path to the Dockerfile to use for building the image.
+* `<image_name>`:  The build context, which is the directory containing the Dockerfile and any other files needed for the build.
+* 
+
+### **⚠️ Network Issue with ROS Docker Builds on IIIT Wi-Fi**
+
+If you try to build a Docker image using **any ROS base image** while connected to  **IIIT college Wi-Fi** , the build **will fail** with a network error:
+
+```
+gpg: keyserver receive failed: Network is unreachable
+```
+
+This happens because IIIT Wi-Fi **blocks connections** to external GPG keyservers needed for verification.
+
+**✅ Solution:**
+Use a **mobile hotspot or another unrestricted network** to successfully build your base ROS image.
 
 ### 3. Pushing an Image (For Contributors)
 
@@ -67,13 +81,11 @@ docker push ghcr.io/soham2560/<image_name>:latest
 
 The following repositories demonstrate how to use these Docker images in real-world ROS 2 projects with Dev Containers.  Each repository includes a `.devcontainer` folder for easy setup.
 
-*   **[LiDAR_Camera_Calibration](https://github.com/soham2560/LiDAR_Camera_Calibration)**: Demonstrates LiDAR-Camera calibration in ROS 2 using the `humble` image within a Dev Container.
-
-*   **[6DOF_ObjectFollowing](https://github.com/soham2560/6DOF_ObjectFollowing)**: Implements a 6-DOF object following system using ROS 2 and the `humble-garden` image within a Dev Container.
-
-*   **[ros2_tutorial_repo](https://github.com/soham2560/ros2_tutorial_repo)**: A basic ROS 2 tutorial repository demonstrating fundamental concepts, configured with the `humble` image within a Dev Container.
-*   **[Husky Mobile robot](https://github.com/RoboticsIIITH/husky_ws)**: Basic ROS Noetic packages for running the Husky mobile robot on AMD64/x86 device.
-*   **[P3DX Mobile robot](https://github.com/rtarun1/P3DX-Docker)**: Basic ROS Noetic packages for running the P3DX mobile robot on AMD64/x86 device.
+* **[LiDAR_Camera_Calibration](https://github.com/soham2560/LiDAR_Camera_Calibration)**: Demonstrates LiDAR-Camera calibration in ROS 2 using the `humble` image within a Dev Container.
+* **[6DOF_ObjectFollowing](https://github.com/soham2560/6DOF_ObjectFollowing)**: Implements a 6-DOF object following system using ROS 2 and the `humble-garden` image within a Dev Container.
+* **[ros2_tutorial_repo](https://github.com/soham2560/ros2_tutorial_repo)**: A basic ROS 2 tutorial repository demonstrating fundamental concepts, configured with the `humble` image within a Dev Container.
+* **[Husky Mobile robot](https://github.com/RoboticsIIITH/husky_ws)**: Basic ROS Noetic packages for running the Husky mobile robot on AMD64/x86 device.
+* **[P3DX Mobile robot](https://github.com/rtarun1/P3DX-Docker)**: Basic ROS Noetic packages for running the P3DX mobile robot on AMD64/x86 device.
 
 ## Contributing
 

--- a/humble/Dockerfile
+++ b/humble/Dockerfile
@@ -10,7 +10,7 @@ ARG USER_GID=$USER_UID
 LABEL org.opencontainers.image.description="ROS2 Development Container"
 LABEL org.opencontainers.image.title="ROS2DevCon"
 LABEL org.opencontainers.image.vendor="Soham Patil"
-LABEL org.opencontainers.image.source="https://github.com/soham2560/DockerForROS2Development"
+LABEL org.opencontainers.image.source="https://github.com/soham2560/DockerForROSDevelopment"
 LABEL maintainer="sohampatil45939@gmail.com"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/iron/Dockerfile
+++ b/iron/Dockerfile
@@ -10,7 +10,7 @@ ARG USER_GID=$USER_UID
 LABEL org.opencontainers.image.description="ROS2 Development Container"
 LABEL org.opencontainers.image.title="ROS2DevCon"
 LABEL org.opencontainers.image.vendor="Soham Patil"
-LABEL org.opencontainers.image.source="https://github.com/soham2560/DockerForROS2Development"
+LABEL org.opencontainers.image.source="https://github.com/soham2560/DockerForROSDevelopment"
 LABEL maintainer="sohampatil45939@gmail.com"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -10,7 +10,7 @@ ARG USER_GID=$USER_UID
 LABEL org.opencontainers.image.description="ROS1 Development Container"
 LABEL org.opencontainers.image.title="ROS1DevCon"
 LABEL org.opencontainers.image.vendor="Tarun R"
-LABEL org.opencontainers.image.source="https://github.com/soham2560/DockerForROS2Development"
+LABEL org.opencontainers.image.source="https://github.com/soham2560/DockerForROSDevelopment"
 LABEL maintainer="tarun.ramak@gmail.com"
 LABEL org.opencontainers.image.licenses="MIT"
 # handle default shell


### PR DESCRIPTION
## Brief 
- Just changed the repo name to `DockerForROSDevelopment`, refer [e898761](https://github.com/soham2560/DockerForROS2Development/pull/24/commits/e898761491f4d901ff441fc099323ad06bc6c31c)